### PR TITLE
Fix Terraform validate subcommand execution

### DIFF
--- a/terramorf
+++ b/terramorf
@@ -187,7 +187,9 @@ if [[ $TERRAMORF_SETTINGS -nt $TERRAMORF_VARSFILE ]]; then
 fi
 
 # Terraform var-file argument
-if [[ -s "$TERRAMORF_VARSFILE" && $command_name != "version" ]]; then
+IGNORE_VARSFILE=("version" "validate")
+
+if [[ -s "$TERRAMORF_VARSFILE" && ! "${IGNORE_VARSFILE[*]}" =~ $command_name ]]; then
     command_args+=("-var-file=$TERRAMORF_VARSFILE")
 fi
 


### PR DESCRIPTION
Suppress `-var-file` option when executing `validate` subcommand.

This is a proposal for fixing issue https://github.com/ecanuto/terramorf/issues/1